### PR TITLE
Adds -syntax 3 to KaSim test suite models

### DIFF
--- a/models/test_suite/cflows/abc-cflow/README
+++ b/models/test_suite/cflows/abc-cflow/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim abc-cflow.ka -seed 924556145 -u event -l 100000 -d output -p 1000 --time-independent || exit 0
+"${KAPPABIN}"KaSim abc-cflow.ka -seed 924556145 -u event -l 100000 -d output -p 1000 --time-independent -syntax 3 || exit 0
 
 #This is the classical abc model. 
 #Perturbations are used:

--- a/models/test_suite/cflows/abc-cflow/output/LOG.ref
+++ b/models/test_suite/cflows/abc-cflow/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2048 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'abc-cflow.ka' '-seed' '924556145' '-u' 'event' '-l' '100000' '-d' 'output' '-p' '1000' '--time-independent'
++ Command line to rerun is: 'KaSim' 'abc-cflow.ka' '-seed' '924556145' '-u' 'event' '-l' '100000' '-d' 'output' '-p' '1000' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/abc-cflow/output/data.csv.ref
+++ b/models/test_suite/cflows/abc-cflow/output/data.csv.ref
@@ -1,4 +1,4 @@
-# Output of 'KaSim' 'abc-cflow.ka' '-seed' '924556145' '-u' 'event' '-l' '100000' '-d' 'output' '-p' '1000' '--time-independent'
+# Output of 'KaSim' 'abc-cflow.ka' '-seed' '924556145' '-u' 'event' '-l' '100000' '-d' 'output' '-p' '1000' '--time-independent' '-syntax' '3'
 "[T]", "AB", "Cuu", "Cpu", "Cpp", "n_c"
 0., 0, 0, 0, 0, 0
 3.18857310231, 698, 0, 0, 0, 0

--- a/models/test_suite/cflows/abc-pert/README
+++ b/models/test_suite/cflows/abc-pert/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim abc-pert.ka -seed 924556145 -u e -l 100000 -p 0 -d output --time-independent -mode batch || exit 0
+"${KAPPABIN}"KaSim abc-pert.ka -seed 924556145 -u e -l 100000 -p 0 -d output --time-independent -mode batch -syntax 3 || exit 0
 
 #This is the classical abc model. 
 #Perturbations are used:

--- a/models/test_suite/cflows/abc-pert/output/LOG.ref
+++ b/models/test_suite/cflows/abc-pert/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2048 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'abc-pert.ka' '-seed' '924556145' '-u' 'e' '-l' '100000' '-p' '0' '-d' 'output' '--time-independent' '-mode' 'batch'
++ Command line to rerun is: 'KaSim' 'abc-pert.ka' '-seed' '924556145' '-u' 'e' '-l' '100000' '-p' '0' '-d' 'output' '--time-independent' '-mode' 'batch' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/abc-pert/output/data.csv.ref
+++ b/models/test_suite/cflows/abc-pert/output/data.csv.ref
@@ -1,4 +1,4 @@
-# Output of 'KaSim' 'abc-pert.ka' '-seed' '924556145' '-u' 'e' '-l' '100000' '-p' '0' '-d' 'output' '--time-independent' '-mode' 'batch'
+# Output of 'KaSim' 'abc-pert.ka' '-seed' '924556145' '-u' 'e' '-l' '100000' '-p' '0' '-d' 'output' '--time-independent' '-mode' 'batch' '-syntax' '3'
 "[T]", "AB", "Cuu", "Cpu", "Cpp", "n_c"
 0., 0, 0, 0, 0, 0
 9.94411282076, 730, 0, 0, 0, 0

--- a/models/test_suite/cflows/abc/README
+++ b/models/test_suite/cflows/abc/README
@@ -1,7 +1,7 @@
 #Command-line:
-"${KAPPABIN}"KaSim abc.ka -mode batch -seed 785872661 --compile -d output -l 0 || exit 0
+"${KAPPABIN}"KaSim abc.ka -mode batch -seed 785872661 --compile -d output -l 0 -syntax 3 || exit 0
 "${KAPPABIN}"KaSim abc.ka -mode batch -var on_rate 1.0E-4 -u event -l 2000 \
--d output -p 20 --time-independent || exit 0
+-d output -p 20 --time-independent -syntax 3 || exit 0
 
 #This is the classical abc model.
 #3 stories are expected, but one is very unlikely.

--- a/models/test_suite/cflows/abc/output/LOG.ref
+++ b/models/test_suite/cflows/abc/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16384 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'abc.ka' '-mode' 'batch' '-seed' '785872661' '--compile' '-d' 'output' '-l' '0'
++ Command line to rerun is: 'KaSim' 'abc.ka' '-mode' 'batch' '-seed' '785872661' '--compile' '-d' 'output' '-l' '0' '-syntax' '3'
 Parsing abc.ka...
 done
 + simulation parameters
@@ -29,7 +29,7 @@ done
 	 -initial conditions
 + Building initial state (16384 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'abc.ka' '-mode' 'batch' '-var' 'on_rate' '1.0E-4' '-u' 'event' '-l' '2000' '-d' 'output' '-p' '20' '--time-independent'
++ Command line to rerun is: 'KaSim' 'abc.ka' '-mode' 'batch' '-var' 'on_rate' '1.0E-4' '-u' 'event' '-l' '2000' '-d' 'output' '-p' '20' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/abc/output/data.csv.ref
+++ b/models/test_suite/cflows/abc/output/data.csv.ref
@@ -1,4 +1,4 @@
-# Output of 'KaSim' 'abc.ka' '-mode' 'batch' '-var' 'on_rate' '1.0E-4' '-u' 'event' '-l' '2000' '-d' 'output' '-p' '20' '--time-independent'
+# Output of 'KaSim' 'abc.ka' '-mode' 'batch' '-var' 'on_rate' '1.0E-4' '-u' 'event' '-l' '2000' '-d' 'output' '-p' '20' '--time-independent' '-syntax' '3'
 "[T]", "AB", "Cuu", "Cpu", "Cpp"
 0., 0, 10000, 0, 0
 0.163219624196, 17, 10000, 0, 0

--- a/models/test_suite/cflows/abc_no_compression_mode/README
+++ b/models/test_suite/cflows/abc_no_compression_mode/README
@@ -1,6 +1,6 @@
 #Command-line:
 "${KAPPABIN}"KaSim abc.ka -mode batch -var on_rate 1.0E-4 -u event -l 2000 \
--d output -p 20 --time-independent || exit 0
+-d output -p 20 --time-independent -syntax 3 || exit 0
 
 #In this version, we have not fixed the compression mode
 #Thus a warning should be reported.

--- a/models/test_suite/cflows/abc_no_compression_mode/output/LOG.ref
+++ b/models/test_suite/cflows/abc_no_compression_mode/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16384 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'abc.ka' '-mode' 'batch' '-var' 'on_rate' '1.0E-4' '-u' 'event' '-l' '2000' '-d' 'output' '-p' '20' '--time-independent'
++ Command line to rerun is: 'KaSim' 'abc.ka' '-mode' 'batch' '-var' 'on_rate' '1.0E-4' '-u' 'event' '-l' '2000' '-d' 'output' '-p' '20' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/cflows/abc_no_compression_mode/output/data.csv.ref
+++ b/models/test_suite/cflows/abc_no_compression_mode/output/data.csv.ref
@@ -1,4 +1,4 @@
-# Output of 'KaSim' 'abc.ka' '-mode' 'batch' '-var' 'on_rate' '1.0E-4' '-u' 'event' '-l' '2000' '-d' 'output' '-p' '20' '--time-independent'
+# Output of 'KaSim' 'abc.ka' '-mode' 'batch' '-var' 'on_rate' '1.0E-4' '-u' 'event' '-l' '2000' '-d' 'output' '-p' '20' '--time-independent' '-syntax' '3'
 "[T]", "AB", "Cuu", "Cpu", "Cpp"
 0., 0, 10000, 0, 0
 0.191170138718, 16, 10000, 0, 0

--- a/models/test_suite/cflows/agents_without_sites/README
+++ b/models/test_suite/cflows/agents_without_sites/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim agents_without_sites.ka -seed 924556145 -u event -l 10000 -d output -p 100 --time-independent || exit 0
+"${KAPPABIN}"KaSim agents_without_sites.ka -seed 924556145 -u event -l 10000 -d output -p 100 --time-independent -syntax 3 || exit 0
 
 #Here we test a classical network (agents have no site).
 #There is only one causal flow. 

--- a/models/test_suite/cflows/agents_without_sites/output/LOG.ref
+++ b/models/test_suite/cflows/agents_without_sites/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16384 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'agents_without_sites.ka' '-seed' '924556145' '-u' 'event' '-l' '10000' '-d' 'output' '-p' '100' '--time-independent'
++ Command line to rerun is: 'KaSim' 'agents_without_sites.ka' '-seed' '924556145' '-u' 'event' '-l' '10000' '-d' 'output' '-p' '100' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/agents_without_sites/output/data.csv.ref
+++ b/models/test_suite/cflows/agents_without_sites/output/data.csv.ref
@@ -1,4 +1,4 @@
-# Output of 'KaSim' 'agents_without_sites.ka' '-seed' '924556145' '-u' 'event' '-l' '10000' '-d' 'output' '-p' '100' '--time-independent'
+# Output of 'KaSim' 'agents_without_sites.ka' '-seed' '924556145' '-u' 'event' '-l' '10000' '-d' 'output' '-p' '100' '--time-independent' '-syntax' '3'
 "[T]", "C"
 0., 0
 0.00987921280956, 0

--- a/models/test_suite/cflows/binding_type/README
+++ b/models/test_suite/cflows/binding_type/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim binding_type.ka -seed 924556145 -l 10000 -u event -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim binding_type.ka -seed 924556145 -l 10000 -u event -d output --time-independent -syntax 3 || exit 0
 
 #In this model, intermediary steps test binding types. 
 

--- a/models/test_suite/cflows/binding_type/output/LOG.ref
+++ b/models/test_suite/cflows/binding_type/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (256 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'binding_type.ka' '-seed' '924556145' '-l' '10000' '-u' 'event' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'binding_type.ka' '-seed' '924556145' '-l' '10000' '-u' 'event' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/bonds_in_creation/README
+++ b/models/test_suite/cflows/bonds_in_creation/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim bonds_in_creation.ka -u time -l 40 -p 0.4  -seed 611463625 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim bonds_in_creation.ka -u time -l 40 -p 0.4  -seed 611463625 -d output --time-independent -syntax 3 || exit 0
 
 #Variation to the test non regression against a fix to a 
 #bug found by Jonathan. 

--- a/models/test_suite/cflows/bonds_in_creation/output/LOG.ref
+++ b/models/test_suite/cflows/bonds_in_creation/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (32 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'bonds_in_creation.ka' '-u' 'time' '-l' '40' '-p' '0.4' '-seed' '611463625' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'bonds_in_creation.ka' '-u' 'time' '-l' '40' '-p' '0.4' '-seed' '611463625' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/bonds_in_creation/output/data.csv.ref
+++ b/models/test_suite/cflows/bonds_in_creation/output/data.csv.ref
@@ -1,4 +1,4 @@
-# Output of 'KaSim' 'bonds_in_creation.ka' '-u' 'time' '-l' '40' '-p' '0.4' '-seed' '611463625' '-d' 'output' '--time-independent'
+# Output of 'KaSim' 'bonds_in_creation.ka' '-u' 'time' '-l' '40' '-p' '0.4' '-seed' '611463625' '-d' 'output' '--time-independent' '-syntax' '3'
 "[T]", "L"
 0., 0
 0.4, 0

--- a/models/test_suite/cflows/bonds_in_init/README
+++ b/models/test_suite/cflows/bonds_in_init/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim bonds_in_init.ka -l 40 -seed 611463625 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim bonds_in_init.ka -l 40 -seed 611463625 -d output --time-independent -syntax 3 || exit 0
 
 #To test non regression against a fix to a 
 #bug found by Jonathan. 

--- a/models/test_suite/cflows/bonds_in_init/output/LOG.ref
+++ b/models/test_suite/cflows/bonds_in_init/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (64 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'bonds_in_init.ka' '-l' '40' '-seed' '611463625' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'bonds_in_init.ka' '-l' '40' '-seed' '611463625' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/cflows_json/README
+++ b/models/test_suite/cflows/cflows_json/README
@@ -1,3 +1,3 @@
 #Command-line:
-"${KAPPABIN}"KaSim json.ka -seed 840540685 -l 5 -d output -trace /tmp/cflow-json-trace.json || exit 0
+"${KAPPABIN}"KaSim json.ka -seed 840540685 -l 5 -d output -trace /tmp/cflow-json-trace.json -syntax 3 || exit 0
 "${KAPPABIN}"KaStor --weak -format json /tmp/cflow-json-trace.json -d output --time-independent || exit 0

--- a/models/test_suite/cflows/cflows_json/output/LOG.ref
+++ b/models/test_suite/cflows/cflows_json/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2048 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'json.ka' '-seed' '840540685' '-l' '5' '-d' 'output' '-trace' '/tmp/cflow-json-trace.json'
++ Command line to rerun is: 'KaSim' 'json.ka' '-seed' '840540685' '-l' '5' '-d' 'output' '-trace' '/tmp/cflow-json-trace.json' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/cflows/cflows_json/output/data.csv.ref
+++ b/models/test_suite/cflows/cflows_json/output/data.csv.ref
@@ -1,4 +1,4 @@
-# Output of 'KaSim' 'json.ka' '-seed' '840540685' '-l' '5' '-d' 'output' '-trace' '/tmp/cflow-json-trace.json'
+# Output of 'KaSim' 'json.ka' '-seed' '840540685' '-l' '5' '-d' 'output' '-trace' '/tmp/cflow-json-trace.json' '-syntax' '3'
 "[T]", "ApBp", "ABA"
 0., 0, 0
 1., 66, 0

--- a/models/test_suite/cflows/create/README
+++ b/models/test_suite/cflows/create/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim create.ka -seed 931056658 -u event -l 500 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim create.ka -seed 931056658 -u event -l 500 -d output --time-independent -syntax 3 || exit 0
 
 #In this example, each A has two sites.  Site x of a A can connect to
 #site y of another A.  Then it can get phosphorylated while

--- a/models/test_suite/cflows/create/output/LOG.ref
+++ b/models/test_suite/cflows/create/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (1024 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'create.ka' '-seed' '931056658' '-u' 'event' '-l' '500' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'create.ka' '-seed' '931056658' '-u' 'event' '-l' '500' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/cube/README
+++ b/models/test_suite/cflows/cube/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim cube.ka -u event -l 30000 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim cube.ka -u event -l 30000 -d output --time-independent -syntax 3 || exit 0
 
 #In this example, each A has three sites which can be activated or
 #not. A configuration can be seen as the vertice of a cube, put the

--- a/models/test_suite/cflows/cube/output/LOG.ref
+++ b/models/test_suite/cflows/cube/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16384 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'cube.ka' '-u' 'event' '-l' '30000' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'cube.ka' '-u' 'event' '-l' '30000' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/distributive/README
+++ b/models/test_suite/cflows/distributive/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim distributive.ka -seed 240056667 -u event -l 250 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim distributive.ka -seed 240056667 -u event -l 250 -d output --time-independent -syntax 3 || exit 0
 
 #Distributive phosphorilation the sites of a protein A.
 #It is highly unlikely that the same kinase is used to phosphorilate the two sites of the protein A. 

--- a/models/test_suite/cflows/distributive/output/LOG.ref
+++ b/models/test_suite/cflows/distributive/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (32 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'distributive.ka' '-seed' '240056667' '-u' 'event' '-l' '250' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'distributive.ka' '-seed' '240056667' '-u' 'event' '-l' '250' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/empty/README
+++ b/models/test_suite/cflows/empty/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim empty.ka -l 6 -d output -seed 126704914 -p 0.2 --time-independent || exit 0
+"${KAPPABIN}"KaSim empty.ka -l 6 -d output -seed 126704914 -p 0.2 --time-independent -syntax 3 || exit 0

--- a/models/test_suite/cflows/empty/output/LOG.ref
+++ b/models/test_suite/cflows/empty/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'empty.ka' '-l' '6' '-d' 'output' '-seed' '126704914' '-p' '0.2' '--time-independent'
++ Command line to rerun is: 'KaSim' 'empty.ka' '-l' '6' '-d' 'output' '-seed' '126704914' '-p' '0.2' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/empty/output/data.csv.ref
+++ b/models/test_suite/cflows/empty/output/data.csv.ref
@@ -1,4 +1,4 @@
-# Output of 'KaSim' 'empty.ka' '-l' '6' '-d' 'output' '-seed' '126704914' '-p' '0.2' '--time-independent'
+# Output of 'KaSim' 'empty.ka' '-l' '6' '-d' 'output' '-seed' '126704914' '-p' '0.2' '--time-independent' '-syntax' '3'
 "[T]", "goal"
 0., 0
 0.2, 1

--- a/models/test_suite/cflows/internal/README
+++ b/models/test_suite/cflows/internal/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim internal.ka -seed 240056667 -u event -l 30000 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim internal.ka -seed 240056667 -u event -l 30000 -d output --time-independent -syntax 3 || exit 0
 
 #Test with modification without test.
 #There should be only one causal flow

--- a/models/test_suite/cflows/internal/output/LOG.ref
+++ b/models/test_suite/cflows/internal/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (1 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'internal.ka' '-seed' '240056667' '-u' 'event' '-l' '30000' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'internal.ka' '-seed' '240056667' '-u' 'event' '-l' '30000' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/link_passing/README
+++ b/models/test_suite/cflows/link_passing/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim link_passing.ka -seed 924556145 -u e -l 10000 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim link_passing.ka -seed 924556145 -u e -l 10000 -d output --time-independent -syntax 3 || exit 0
 
 #In this model K can connect to A on x. 
 #Then the link can be pass from A.x to A.y, and from A.y to A.z. 

--- a/models/test_suite/cflows/link_passing/output/LOG.ref
+++ b/models/test_suite/cflows/link_passing/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'link_passing.ka' '-seed' '924556145' '-u' 'e' '-l' '10000' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'link_passing.ka' '-seed' '924556145' '-u' 'e' '-l' '10000' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/link_passing_strong1/README
+++ b/models/test_suite/cflows/link_passing_strong1/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim link_passing_strong1.ka -seed 611463625 -u event -l 100 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim link_passing_strong1.ka -seed 611463625 -u event -l 100 -d output --time-independent -syntax 3 || exit 0
 
 #In this examples, free A can turn into free B, which can turn into free C, which can turn into free A
 #Each agent has a site x

--- a/models/test_suite/cflows/link_passing_strong1/output/LOG.ref
+++ b/models/test_suite/cflows/link_passing_strong1/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'link_passing_strong1.ka' '-seed' '611463625' '-u' 'event' '-l' '100' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'link_passing_strong1.ka' '-seed' '611463625' '-u' 'event' '-l' '100' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/link_passing_strong2/README
+++ b/models/test_suite/cflows/link_passing_strong2/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim link_passing_strong2.ka -seed 611463625 -u event -l 280 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim link_passing_strong2.ka -seed 611463625 -u event -l 280 -d output --time-independent -syntax 3 || exit 0
 
 #In this examples, free A can turn into free B, which can turn into free C, which can turn into free A
 #Each agent has a site x

--- a/models/test_suite/cflows/link_passing_strong2/output/LOG.ref
+++ b/models/test_suite/cflows/link_passing_strong2/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (32 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'link_passing_strong2.ka' '-seed' '611463625' '-u' 'event' '-l' '280' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'link_passing_strong2.ka' '-seed' '611463625' '-u' 'event' '-l' '280' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/link_passing_strong3/README
+++ b/models/test_suite/cflows/link_passing_strong3/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim link_passing_strong3.ka -seed 611463625 -u event -l 280 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim link_passing_strong3.ka -seed 611463625 -u event -l 280 -d output --time-independent -syntax 3 || exit 0
 
 #In this examples, free A can turn into free B, which can turn into free C, which can turn into free A
 #Each agent has a site x

--- a/models/test_suite/cflows/link_passing_strong3/output/LOG.ref
+++ b/models/test_suite/cflows/link_passing_strong3/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (32 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'link_passing_strong3.ka' '-seed' '611463625' '-u' 'event' '-l' '280' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'link_passing_strong3.ka' '-seed' '611463625' '-u' 'event' '-l' '280' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/link_passing_strong4/README
+++ b/models/test_suite/cflows/link_passing_strong4/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim link_passing_strong4.ka -seed 924556145 -u e -l 10000 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim link_passing_strong4.ka -seed 924556145 -u e -l 10000 -d output --time-independent -syntax 3 || exit 0
 
 #In this model K can connect to A on x. 
 #Then the link can be pass from A.x to A.y, and from A.y to A.z. 

--- a/models/test_suite/cflows/link_passing_strong4/output/LOG.ref
+++ b/models/test_suite/cflows/link_passing_strong4/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'link_passing_strong4.ka' '-seed' '924556145' '-u' 'e' '-l' '10000' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'link_passing_strong4.ka' '-seed' '924556145' '-u' 'e' '-l' '10000' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/link_passing_strong_create/README
+++ b/models/test_suite/cflows/link_passing_strong_create/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim link_passing_strong_create.ka -seed 611463625 -u event -l 100 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim link_passing_strong_create.ka -seed 611463625 -u event -l 100 -d output --time-independent -syntax 3 || exit 0
 
 #In this examples, free A can turn into free B, which can turn into free C, which can turn into free A
 #Each agent has a site x

--- a/models/test_suite/cflows/link_passing_strong_create/output/LOG.ref
+++ b/models/test_suite/cflows/link_passing_strong_create/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'link_passing_strong_create.ka' '-seed' '611463625' '-u' 'event' '-l' '100' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'link_passing_strong_create.ka' '-seed' '611463625' '-u' 'event' '-l' '100' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/link_swapping/README
+++ b/models/test_suite/cflows/link_swapping/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim link_swapping.ka -seed 924556145 -u event -l 3 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim link_swapping.ka -seed 924556145 -u event -l 3 -d output --time-independent -syntax 3 || exit 0
 
 #In this model As can form a dimmer by connecting their two x(s), and their two y(s) concurrently. 
 #Then, they can swap these links to bind a site x to the site y of the other A, and vice versa (which triggers the observable).

--- a/models/test_suite/cflows/link_swapping/output/LOG.ref
+++ b/models/test_suite/cflows/link_swapping/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'link_swapping.ka' '-seed' '924556145' '-u' 'event' '-l' '3' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'link_swapping.ka' '-seed' '924556145' '-u' 'event' '-l' '3' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/link_swapping_strong1/README
+++ b/models/test_suite/cflows/link_swapping_strong1/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim link_swapping_strong1.ka -seed 924556145 -u event -l 300 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim link_swapping_strong1.ka -seed 924556145 -u event -l 300 -d output --time-independent -syntax 3 || exit 0
 
 #In this model 
 #A can turn into B and B can turn into A

--- a/models/test_suite/cflows/link_swapping_strong1/output/LOG.ref
+++ b/models/test_suite/cflows/link_swapping_strong1/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'link_swapping_strong1.ka' '-seed' '924556145' '-u' 'event' '-l' '300' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'link_swapping_strong1.ka' '-seed' '924556145' '-u' 'event' '-l' '300' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/link_swapping_strong2/README
+++ b/models/test_suite/cflows/link_swapping_strong2/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim link_swapping_strong2.ka -seed 924556145 -u e -l 300 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim link_swapping_strong2.ka -seed 924556145 -u e -l 300 -d output --time-independent -syntax 3 || exit 0
 
 #In this model 
 #A can turn into C and C can turn into A

--- a/models/test_suite/cflows/link_swapping_strong2/output/LOG.ref
+++ b/models/test_suite/cflows/link_swapping_strong2/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'link_swapping_strong2.ka' '-seed' '924556145' '-u' 'e' '-l' '300' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'link_swapping_strong2.ka' '-seed' '924556145' '-u' 'e' '-l' '300' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/link_swapping_strong3/README
+++ b/models/test_suite/cflows/link_swapping_strong3/README
@@ -1,6 +1,6 @@
 #Command-line:
 "${KAPPABIN}"KaSim -i link_swapping_strong3.ka -seed 924556145 -u event -l 30 \
-  -d output --debug --time-independent || exit 0
+  -d output --debug --time-independent -syntax 3 || exit 0
 
 #In this model As can form a dimmer by connecting their two x(s), and
 #their two y(s) concurrently.

--- a/models/test_suite/cflows/link_swapping_strong3/output/LOG.ref
+++ b/models/test_suite/cflows/link_swapping_strong3/output/LOG.ref
@@ -22,7 +22,7 @@ On roots:
 Rule A(x), A(x) -> A(x!1), A(x!1) has now 64 instances.
  (8 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-i' 'link_swapping_strong3.ka' '-seed' '924556145' '-u' 'event' '-l' '30' '-d' 'output' '--debug' '--time-independent'
++ Command line to rerun is: 'KaSim' '-i' 'link_swapping_strong3.ka' '-seed' '924556145' '-u' 'event' '-l' '30' '-d' 'output' '--debug' '--time-independent' '-syntax' '3'
 Applied 0:
 (ast: 1) 0: /*cc1*/ A/*1*/(x!.), 1: /*cc1*/ A/*1*/(x!.)
 -- A/*1*//*1*/.x = ⊥, A/*1*//*0*/.x = ⊥ ++ A/*1*//*1*/.x = A/*1*//*0*/.x

--- a/models/test_suite/cflows/nasty/README
+++ b/models/test_suite/cflows/nasty/README
@@ -1,4 +1,4 @@
 #Command-line:
-"${KAPPABIN}"KaSim nasty.ka -seed 924556145 -u event -l 100 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim nasty.ka -seed 924556145 -u event -l 100 -d output --time-independent -syntax 3 || exit 0
 
 #we check that the computation of causal stories work well when only the none option is used

--- a/models/test_suite/cflows/nasty/output/LOG.ref
+++ b/models/test_suite/cflows/nasty/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'nasty.ka' '-seed' '924556145' '-u' 'event' '-l' '100' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'nasty.ka' '-seed' '924556145' '-u' 'event' '-l' '100' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/none_only/README
+++ b/models/test_suite/cflows/none_only/README
@@ -1,4 +1,4 @@
 #Command-line:
-"${KAPPABIN}"KaSim none_only.ka -seed 627933151 -u event -l 1000 -d output -p 20 --time-independent || exit 0
+"${KAPPABIN}"KaSim none_only.ka -seed 627933151 -u event -l 1000 -d output -p 20 --time-independent -syntax 3 || exit 0
 
 #we check that the computation of causal stories work well when only the none option is used

--- a/models/test_suite/cflows/none_only/output/LOG.ref
+++ b/models/test_suite/cflows/none_only/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (32 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'none_only.ka' '-seed' '627933151' '-u' 'event' '-l' '1000' '-d' 'output' '-p' '20' '--time-independent'
++ Command line to rerun is: 'KaSim' 'none_only.ka' '-seed' '627933151' '-u' 'event' '-l' '1000' '-d' 'output' '-p' '20' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/none_only/output/data.csv.ref
+++ b/models/test_suite/cflows/none_only/output/data.csv.ref
@@ -1,4 +1,4 @@
-# Output of 'KaSim' 'none_only.ka' '-seed' '627933151' '-u' 'event' '-l' '1000' '-d' 'output' '-p' '20' '--time-independent'
+# Output of 'KaSim' 'none_only.ka' '-seed' '627933151' '-u' 'event' '-l' '1000' '-d' 'output' '-p' '20' '--time-independent' '-syntax' '3'
 "[T]", "AB", "Cuu", "Cpu", "Cpp", "n_c"
 0., 0, 0, 0, 0, 0
 34.4380659299, 2, 9994, 6, 0, 10000

--- a/models/test_suite/cflows/observables/README
+++ b/models/test_suite/cflows/observables/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim -i observables.ka -seed 924556145 -u event -l 10000 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim -i observables.ka -seed 924556145 -u event -l 10000 -d output --time-independent -syntax 3 || exit 0
 
 #In this example A and B are synchronized. 
 #They are either both activated, or both not activated. 

--- a/models/test_suite/cflows/observables/output/LOG.ref
+++ b/models/test_suite/cflows/observables/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-i' 'observables.ka' '-seed' '924556145' '-u' 'event' '-l' '10000' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' '-i' 'observables.ka' '-seed' '924556145' '-u' 'event' '-l' '10000' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/processive/README
+++ b/models/test_suite/cflows/processive/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim -i processive.ka -seed 240056667 -u event -l 30000 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim -i processive.ka -seed 240056667 -u event -l 30000 -d output --time-independent -syntax 3 || exit 0
 
 #Processive phosphorilation the sites of a protein A.
 #Even it the kinase breaks its connection, and another kinase finish the job, the strong compression will merge the two Ks and detect that the unbinding was unecessary. 

--- a/models/test_suite/cflows/processive/output/LOG.ref
+++ b/models/test_suite/cflows/processive/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (32 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-i' 'processive.ka' '-seed' '240056667' '-u' 'event' '-l' '30000' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' '-i' 'processive.ka' '-seed' '240056667' '-u' 'event' '-l' '30000' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/pseudo_inverse/README
+++ b/models/test_suite/cflows/pseudo_inverse/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim pseudo.ka -seed 924556145 -var n_a 1000 -u e -l 10000 -d output --time-independent -p 100 || exit 0
+"${KAPPABIN}"KaSim pseudo.ka -seed 924556145 -var n_a 1000 -u e -l 10000 -d output --time-independent -p 100 -syntax 3 || exit 0
 
 #This is the classical abc model.
 #3 stories are expected, but one is very unlikly.

--- a/models/test_suite/cflows/pseudo_inverse/output/LOG.ref
+++ b/models/test_suite/cflows/pseudo_inverse/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (1024 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'pseudo.ka' '-seed' '924556145' '-var' 'n_a' '1000' '-u' 'e' '-l' '10000' '-d' 'output' '--time-independent' '-p' '100'
++ Command line to rerun is: 'KaSim' 'pseudo.ka' '-seed' '924556145' '-var' 'n_a' '1000' '-u' 'e' '-l' '10000' '-d' 'output' '--time-independent' '-p' '100' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/pseudo_inverse/output/data.csv.ref
+++ b/models/test_suite/cflows/pseudo_inverse/output/data.csv.ref
@@ -1,4 +1,4 @@
-# Output of 'KaSim' 'pseudo.ka' '-seed' '924556145' '-var' 'n_a' '1000' '-u' 'e' '-l' '10000' '-d' 'output' '--time-independent' '-p' '100'
+# Output of 'KaSim' 'pseudo.ka' '-seed' '924556145' '-var' 'n_a' '1000' '-u' 'e' '-l' '10000' '-d' 'output' '--time-independent' '-p' '100' '-syntax' '3'
 "[T]", "c"
 0., 0
 0.0526567245143, 0

--- a/models/test_suite/cflows/side-effects1/README
+++ b/models/test_suite/cflows/side-effects1/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim side-effects.ka -seed 924556145 -u Event -l 10000 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim side-effects.ka -seed 924556145 -u Event -l 10000 -d output --time-independent -syntax 3 || exit 0
 
 #The observable is triggerred when there is a B that is bound and a C that is free and not phosphorilated. 
 

--- a/models/test_suite/cflows/side-effects1/output/LOG.ref
+++ b/models/test_suite/cflows/side-effects1/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (4 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'side-effects.ka' '-seed' '924556145' '-u' 'Event' '-l' '10000' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'side-effects.ka' '-seed' '924556145' '-u' 'Event' '-l' '10000' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/side-effects2/README
+++ b/models/test_suite/cflows/side-effects2/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim side-effects.ka -seed 924556145 -u Event -l 12 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim side-effects.ka -seed 924556145 -u Event -l 12 -d output --time-independent -syntax 3 || exit 0
 #KaSim side-effects.ka -seed 924556145 -e 22 -d output || exit 0
 
 #The observable is triggerred when there is a B that is free and a C that is free and not phosphorilated. 

--- a/models/test_suite/cflows/side-effects2/output/LOG.ref
+++ b/models/test_suite/cflows/side-effects2/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (64 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'side-effects.ka' '-seed' '924556145' '-u' 'Event' '-l' '12' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'side-effects.ka' '-seed' '924556145' '-u' 'Event' '-l' '12' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/side-effects3/README
+++ b/models/test_suite/cflows/side-effects3/README
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-"${KAPPABIN}"KaSim -i side-effects.ka -seed 501792230 -u event -l 199 -d output -trace trace.json || exit 0
+"${KAPPABIN}"KaSim -i side-effects.ka -seed 501792230 -u event -l 199 -d output -trace trace.json -syntax 3 || exit 0
 "${KAPPABIN}"KaStor -d output --none --weak --time-independent output/trace.json || exit 0
 
 #Test KaStor

--- a/models/test_suite/cflows/side-effects3/output/LOG.ref
+++ b/models/test_suite/cflows/side-effects3/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-i' 'side-effects.ka' '-seed' '501792230' '-u' 'event' '-l' '199' '-d' 'output' '-trace' 'trace.json'
++ Command line to rerun is: 'KaSim' '-i' 'side-effects.ka' '-seed' '501792230' '-u' 'event' '-l' '199' '-d' 'output' '-trace' 'trace.json' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/cflows/side-effects4/README
+++ b/models/test_suite/cflows/side-effects4/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim side-effects.ka -u e -l 25 -seed 253329392 -d output --time-independent || exit 0 
+"${KAPPABIN}"KaSim side-effects.ka -u e -l 25 -seed 253329392 -d output --time-independent -syntax 3 || exit 0 
 
 
 #A and B can for dimmer.

--- a/models/test_suite/cflows/side-effects4/output/LOG.ref
+++ b/models/test_suite/cflows/side-effects4/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'side-effects.ka' '-u' 'e' '-l' '25' '-seed' '253329392' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'side-effects.ka' '-u' 'e' '-l' '25' '-seed' '253329392' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/side-effects5/README
+++ b/models/test_suite/cflows/side-effects5/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim -i side-effects.ka -u event -l 25 -seed 253329392 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim -i side-effects.ka -u event -l 25 -seed 253329392 -d output --time-independent -syntax 3 || exit 0
 
 
 #A and B can for dimmer.

--- a/models/test_suite/cflows/side-effects5/output/LOG.ref
+++ b/models/test_suite/cflows/side-effects5/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-i' 'side-effects.ka' '-u' 'event' '-l' '25' '-seed' '253329392' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' '-i' 'side-effects.ka' '-u' 'event' '-l' '25' '-seed' '253329392' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/weak_events/README
+++ b/models/test_suite/cflows/weak_events/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim weak_events.ka -seed 924556145 -u e -l 75 -d output --time-independent || exit 0
+"${KAPPABIN}"KaSim weak_events.ka -seed 924556145 -u e -l 75 -d output --time-independent -syntax 3 || exit 0
 
 #This is the classical abc model. 
 #3 stories are expected, but one is very unlikely.

--- a/models/test_suite/cflows/weak_events/output/LOG.ref
+++ b/models/test_suite/cflows/weak_events/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (1024 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'weak_events.ka' '-seed' '924556145' '-u' 'e' '-l' '75' '-d' 'output' '--time-independent'
++ Command line to rerun is: 'KaSim' 'weak_events.ka' '-seed' '924556145' '-u' 'e' '-l' '75' '-d' 'output' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/weak_only/README
+++ b/models/test_suite/cflows/weak_only/README
@@ -1,4 +1,4 @@
 #Command-line:
-"${KAPPABIN}"KaSim -i weak_only.ka -seed 924556145 -u event -l 100000 -d output -o data.svg -p 1000 --time-independent || exit 0
+"${KAPPABIN}"KaSim -i weak_only.ka -seed 924556145 -u event -l 100000 -d output -o data.svg -p 1000 --time-independent -syntax 3 || exit 0
 
 #Here we should show only weakly compressed flows.

--- a/models/test_suite/cflows/weak_only/output/LOG.ref
+++ b/models/test_suite/cflows/weak_only/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2048 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-i' 'weak_only.ka' '-seed' '924556145' '-u' 'event' '-l' '100000' '-d' 'output' '-o' 'data.svg' '-p' '1000' '--time-independent'
++ Command line to rerun is: 'KaSim' '-i' 'weak_only.ka' '-seed' '924556145' '-u' 'event' '-l' '100000' '-d' 'output' '-o' 'data.svg' '-p' '1000' '--time-independent' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 + Loading trace

--- a/models/test_suite/cflows/weak_only/output/data.svg.ref
+++ b/models/test_suite/cflows/weak_only/output/data.svg.ref
@@ -4,7 +4,7 @@
 
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="600">
-<title>Output of 'KaSim' '-i' 'weak_only.ka' '-seed' '924556145' '-u' 'event' '-l' '100000' '-d' 'output' '-o' 'data.svg' '-p' '1000' '--time-independent'</title>
+<title>Output of 'KaSim' '-i' 'weak_only.ka' '-seed' '924556145' '-u' 'event' '-l' '100000' '-d' 'output' '-o' 'data.svg' '-p' '1000' '--time-independent' '-syntax' '3'</title>
 
 <style type="text/css" >
 <![CDATA[

--- a/models/test_suite/compiler/counters/README
+++ b/models/test_suite/compiler/counters/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -l 1 -seed 442310228 -d output counters.ka || true
+"${KAPPABIN}"KaSim -l 1 -seed 442310228 -d output counters.ka -syntax 3 || true

--- a/models/test_suite/compiler/counters/output/LOG.ref
+++ b/models/test_suite/compiler/counters/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (64 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '1' '-seed' '442310228' '-d' 'output' 'counters.ka'
++ Command line to rerun is: 'KaSim' '-l' '1' '-seed' '442310228' '-d' 'output' 'counters.ka' '-syntax' '3'
 ____________________________________________________________
 #######
 Counter c of agent A reached maximum

--- a/models/test_suite/compiler/counters/output/data.csv.ref
+++ b/models/test_suite/compiler/counters/output/data.csv.ref
@@ -1,3 +1,3 @@
-# Output of 'KaSim' '-l' '1' '-seed' '442310228' '-d' 'output' 'counters.ka'
+# Output of 'KaSim' '-l' '1' '-seed' '442310228' '-d' 'output' 'counters.ka' '-syntax' '3'
 "[T]", "A1"
 0., 0

--- a/models/test_suite/compiler/counters_2_levels/README
+++ b/models/test_suite/compiler/counters_2_levels/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -l 1 -seed 92067277 -d output counter_2.ka || true
+"${KAPPABIN}"KaSim -l 1 -seed 92067277 -d output counter_2.ka -syntax 3 || true

--- a/models/test_suite/compiler/counters_2_levels/output/LOG.ref
+++ b/models/test_suite/compiler/counters_2_levels/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (128 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '1' '-seed' '92067277' '-d' 'output' 'counter_2.ka'
++ Command line to rerun is: 'KaSim' '-l' '1' '-seed' '92067277' '-d' 'output' 'counter_2.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/compiler/counters_init_pert/README
+++ b/models/test_suite/compiler/counters_init_pert/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -l 1 -seed 92067277 -d output counter.ka || true
+"${KAPPABIN}"KaSim -l 1 -seed 92067277 -d output counter.ka -syntax 3 || true

--- a/models/test_suite/compiler/counters_init_pert/output/LOG.ref
+++ b/models/test_suite/compiler/counters_init_pert/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (32 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '1' '-seed' '92067277' '-d' 'output' 'counter.ka'
++ Command line to rerun is: 'KaSim' '-l' '1' '-seed' '92067277' '-d' 'output' 'counter.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/compiler/counters_perturbation/README
+++ b/models/test_suite/compiler/counters_perturbation/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -l 10 -seed 92067277 -d output counter_max.ka || true
+"${KAPPABIN}"KaSim -l 10 -seed 92067277 -d output counter_max.ka -syntax 3 || true

--- a/models/test_suite/compiler/counters_perturbation/output/LOG.ref
+++ b/models/test_suite/compiler/counters_perturbation/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (128 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '10' '-seed' '92067277' '-d' 'output' 'counter_max.ka'
++ Command line to rerun is: 'KaSim' '-l' '10' '-seed' '92067277' '-d' 'output' 'counter_max.ka' '-syntax' '3'
 ____________________________________________________________
 
 Counter c of agent A reached maximum

--- a/models/test_suite/compiler/counters_signature_with_contact_map/README
+++ b/models/test_suite/compiler/counters_signature_with_contact_map/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -l 10 -seed 92067277 -d output sigs_contact.ka || true
+"${KAPPABIN}"KaSim -l 10 -seed 92067277 -d output sigs_contact.ka -syntax 3 || true

--- a/models/test_suite/compiler/counters_signature_with_contact_map/output/LOG.ref
+++ b/models/test_suite/compiler/counters_signature_with_contact_map/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (64 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '10' '-seed' '92067277' '-d' 'output' 'sigs_contact.ka'
++ Command line to rerun is: 'KaSim' '-l' '10' '-seed' '92067277' '-d' 'output' 'sigs_contact.ka' '-syntax' '3'
 ____________________________________________________________
 #############
 Counter c of agent B reached maximum

--- a/models/test_suite/compiler/counters_syntax_errors/README
+++ b/models/test_suite/compiler/counters_syntax_errors/README
@@ -1,7 +1,7 @@
-"${KAPPABIN}"KaSim -seed 92067277 -d output counter_name_twice.ka --compile || true
-"${KAPPABIN}"KaSim -seed 92067277 -d output counter_not_enough_spec.ka --compile || true
-"${KAPPABIN}"KaSim -seed 92067277 -d output modif_lhs.ka --compile || true
-"${KAPPABIN}"KaSim -seed 92067277 -d output negative_delta_too_big.ka --compile || true
-"${KAPPABIN}"KaSim -seed 92067277 -d output test_rhs.ka --compile || true
-"${KAPPABIN}"KaSim -seed 92067277 -d output var_not_spec.ka --compile || true
-"${KAPPABIN}"KaSim -seed 92067277 -d output counter_not_declared.ka --compile || true
+"${KAPPABIN}"KaSim -seed 92067277 -d output counter_name_twice.ka --compile -syntax 3 || true
+"${KAPPABIN}"KaSim -seed 92067277 -d output counter_not_enough_spec.ka --compile -syntax 3 || true
+"${KAPPABIN}"KaSim -seed 92067277 -d output modif_lhs.ka --compile -syntax 3 || true
+"${KAPPABIN}"KaSim -seed 92067277 -d output negative_delta_too_big.ka --compile -syntax 3 || true
+"${KAPPABIN}"KaSim -seed 92067277 -d output test_rhs.ka --compile -syntax 3 || true
+"${KAPPABIN}"KaSim -seed 92067277 -d output var_not_spec.ka --compile -syntax 3 || true
+"${KAPPABIN}"KaSim -seed 92067277 -d output counter_not_declared.ka --compile -syntax 3 || true

--- a/models/test_suite/compiler/file_order/README
+++ b/models/test_suite/compiler/file_order/README
@@ -1,2 +1,2 @@
 #!/bin/sh
-"${KAPPABIN}"KaSim file1.ka file2.ka -mode batch --compile -d output -l 0 || exit 0
+"${KAPPABIN}"KaSim file1.ka file2.ka -mode batch --compile -d output -l 0 -syntax 3 || exit 0

--- a/models/test_suite/compiler/file_order/output/LOG.ref
+++ b/models/test_suite/compiler/file_order/output/LOG.ref
@@ -15,4 +15,4 @@ done
 	 -initial conditions
 + Building initial state (1 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'file1.ka' 'file2.ka' '-mode' 'batch' '--compile' '-d' 'output' '-l' '0'
++ Command line to rerun is: 'KaSim' 'file1.ka' 'file2.ka' '-mode' 'batch' '--compile' '-d' 'output' '-l' '0' '-syntax' '3'

--- a/models/test_suite/compiler/lpc1/README
+++ b/models/test_suite/compiler/lpc1/README
@@ -1,3 +1,3 @@
 #Command-line:
-"${KAPPABIN}"KaSim lpc1.ka -seed 785872661 -u events -l 2 -d output || exit 0
+"${KAPPABIN}"KaSim lpc1.ka -seed 785872661 -u events -l 2 -d output -syntax 3 || exit 0
 

--- a/models/test_suite/compiler/lpc1/output/LOG.ref
+++ b/models/test_suite/compiler/lpc1/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (4 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'lpc1.ka' '-seed' '785872661' '-u' 'events' '-l' '2' '-d' 'output'
++ Command line to rerun is: 'KaSim' 'lpc1.ka' '-seed' '785872661' '-u' 'events' '-l' '2' '-d' 'output' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/compiler/lpc2/README
+++ b/models/test_suite/compiler/lpc2/README
@@ -1,3 +1,3 @@
 #Command-line:
-"${KAPPABIN}"KaSim lpc2.ka -seed 924556145 -u event -l 2 -d output || exit 0
+"${KAPPABIN}"KaSim lpc2.ka -seed 924556145 -u event -l 2 -d output -syntax 3 || exit 0
 

--- a/models/test_suite/compiler/site_twice_in_agent/README
+++ b/models/test_suite/compiler/site_twice_in_agent/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaSim lhs.ka -seed 924556145 -d output --compile || true
-"${KAPPABIN}"KaSim rhs.ka -seed 924556145 -d output --compile || true
-"${KAPPABIN}"KaSim internal.ka -seed 924556145 -d output --compile || true
-"${KAPPABIN}"KaSim remove.ka -seed 924556145 -d output --compile || true
+"${KAPPABIN}"KaSim lhs.ka -seed 924556145 -d output --compile -syntax 3 || true
+"${KAPPABIN}"KaSim rhs.ka -seed 924556145 -d output --compile -syntax 3 || true
+"${KAPPABIN}"KaSim internal.ka -seed 924556145 -d output --compile -syntax 3 || true
+"${KAPPABIN}"KaSim remove.ka -seed 924556145 -d output --compile -syntax 3 || true

--- a/models/test_suite/compiler/symmetry/README
+++ b/models/test_suite/compiler/symmetry/README
@@ -1,2 +1,2 @@
 #!/bin/sh
-"${KAPPABIN}"KaSim symmetry.ka -seed 880671133 --compile -d output -l 0 || exit 0
+"${KAPPABIN}"KaSim symmetry.ka -seed 880671133 --compile -d output -l 0 -syntax 3 || exit 0

--- a/models/test_suite/compiler/symmetry/output/LOG.ref
+++ b/models/test_suite/compiler/symmetry/output/LOG.ref
@@ -13,4 +13,4 @@ done
 	 -initial conditions
 + Building initial state (1 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'symmetry.ka' '-seed' '880671133' '--compile' '-d' 'output' '-l' '0'
++ Command line to rerun is: 'KaSim' 'symmetry.ka' '-seed' '880671133' '--compile' '-d' 'output' '-l' '0' '-syntax' '3'

--- a/models/test_suite/compiler/tokens/README
+++ b/models/test_suite/compiler/tokens/README
@@ -1,2 +1,2 @@
 #!/bin/sh
-"${KAPPABIN}"KaSim tokens.ka -seed 580151237 --compile -d output -l 0 || exit 0
+"${KAPPABIN}"KaSim tokens.ka -seed 580151237 --compile -d output -l 0 -syntax 3 || exit 0

--- a/models/test_suite/compiler/tokens/output/LOG.ref
+++ b/models/test_suite/compiler/tokens/output/LOG.ref
@@ -13,4 +13,4 @@ done
 	 -initial conditions
 + Building initial state (1 agents)
 Done
-+ Command line to rerun is: 'KaSim' 'tokens.ka' '-seed' '580151237' '--compile' '-d' 'output' '-l' '0'
++ Command line to rerun is: 'KaSim' 'tokens.ka' '-seed' '580151237' '--compile' '-d' 'output' '-l' '0' '-syntax' '3'

--- a/models/test_suite/compiler/twice_in_signature/README
+++ b/models/test_suite/compiler/twice_in_signature/README
@@ -1,2 +1,2 @@
 #Command-line:
-"${KAPPABIN}"KaSim twice_in_signature.ka -seed 23014 -d output --compile || true
+"${KAPPABIN}"KaSim twice_in_signature.ka -seed 23014 -d output --compile -syntax 3 || true

--- a/models/test_suite/simulation/activity/README
+++ b/models/test_suite/simulation/activity/README
@@ -1,2 +1,2 @@
-"${KAPPABIN}"KaSim -u event -l 1000 -seed 226011309 -o data.svg -d output -p 20 activity.ka || true
+"${KAPPABIN}"KaSim -u event -l 1000 -seed 226011309 -o data.svg -d output -p 20 activity.ka -syntax 3 || true
 # The growth must be exponential

--- a/models/test_suite/simulation/activity/output/LOG.ref
+++ b/models/test_suite/simulation/activity/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-u' 'event' '-l' '1000' '-seed' '226011309' '-o' 'data.svg' '-d' 'output' '-p' '20' 'activity.ka'
++ Command line to rerun is: 'KaSim' '-u' 'event' '-l' '1000' '-seed' '226011309' '-o' 'data.svg' '-d' 'output' '-p' '20' 'activity.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/activity/output/data.svg.ref
+++ b/models/test_suite/simulation/activity/output/data.svg.ref
@@ -4,7 +4,7 @@
 
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="600">
-<title>Output of 'KaSim' '-u' 'event' '-l' '1000' '-seed' '226011309' '-o' 'data.svg' '-d' 'output' '-p' '20' 'activity.ka'</title>
+<title>Output of 'KaSim' '-u' 'event' '-l' '1000' '-seed' '226011309' '-o' 'data.svg' '-d' 'output' '-p' '20' 'activity.ka' '-syntax' '3'</title>
 
 <style type="text/css" >
 <![CDATA[

--- a/models/test_suite/simulation/clash/README
+++ b/models/test_suite/simulation/clash/README
@@ -1,4 +1,4 @@
 #Command-line:
-"${KAPPABIN}"KaSim -i clash.ka -seed 728130018 -u event -l 3 -d output || exit 0
+"${KAPPABIN}"KaSim -i clash.ka -seed 728130018 -u event -l 3 -d output -syntax 3 || exit 0
 
 #A model where a pair (embedding,rule) do not have a pushout

--- a/models/test_suite/simulation/clash/output/LOG.ref
+++ b/models/test_suite/simulation/clash/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-i' 'clash.ka' '-seed' '728130018' '-u' 'event' '-l' '3' '-d' 'output'
++ Command line to rerun is: 'KaSim' '-i' 'clash.ka' '-seed' '728130018' '-u' 'event' '-l' '3' '-d' 'output' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/clashing_instances/README
+++ b/models/test_suite/simulation/clashing_instances/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -u event -l 120 -d output clashing_instances.ka -seed 923639563 --debug || exit 0
+"${KAPPABIN}"KaSim -u event -l 120 -d output clashing_instances.ka -seed 923639563 --debug -syntax 3 || exit 0

--- a/models/test_suite/simulation/clashing_instances/output/LOG.ref
+++ b/models/test_suite/simulation/clashing_instances/output/LOG.ref
@@ -114,7 +114,7 @@ On roots:
 Rule rule has now 10000 instances.
  (128 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-u' 'event' '-l' '120' '-d' 'output' 'clashing_instances.ka' '-seed' '923639563' '--debug'
++ Command line to rerun is: 'KaSim' '-u' 'event' '-l' '120' '-d' 'output' 'clashing_instances.ka' '-seed' '923639563' '--debug' '-syntax' '3'
 Applied 0:
 (ast: 1) 0: /*cc1*/ A/*1*/(), 1: /*cc2*/ A/*1*/(x!.)
 -- A/*1*//*1*/.x = ⊥, A/*1*//*1*/ ++  @1

--- a/models/test_suite/simulation/del_pert/README
+++ b/models/test_suite/simulation/del_pert/README
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"${KAPPABIN}"KaSim -l 3 -d output -seed 199095194 del_pert.ka || exit 0
+"${KAPPABIN}"KaSim -l 3 -d output -seed 199095194 del_pert.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/del_pert/output/LOG.ref
+++ b/models/test_suite/simulation/del_pert/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (2 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '3' '-d' 'output' '-seed' '199095194' 'del_pert.ka'
++ Command line to rerun is: 'KaSim' '-l' '3' '-d' 'output' '-seed' '199095194' 'del_pert.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/distance1_unary_abbc/README
+++ b/models/test_suite/simulation/distance1_unary_abbc/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -u e -l 200 -seed 904918633 -o data.svg -d output -p 4 abbc.ka || exit 0
+"${KAPPABIN}"KaSim -u e -l 200 -seed 904918633 -o data.svg -d output -p 4 abbc.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/distance1_unary_abbc/output/LOG.ref
+++ b/models/test_suite/simulation/distance1_unary_abbc/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (512 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-u' 'e' '-l' '200' '-seed' '904918633' '-o' 'data.svg' '-d' 'output' '-p' '4' 'abbc.ka'
++ Command line to rerun is: 'KaSim' '-u' 'e' '-l' '200' '-seed' '904918633' '-o' 'data.svg' '-d' 'output' '-p' '4' 'abbc.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/distance1_unary_abbc/output/data.svg.ref
+++ b/models/test_suite/simulation/distance1_unary_abbc/output/data.svg.ref
@@ -4,7 +4,7 @@
 
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="600">
-<title>Output of 'KaSim' '-u' 'e' '-l' '200' '-seed' '904918633' '-o' 'data.svg' '-d' 'output' '-p' '4' 'abbc.ka'</title>
+<title>Output of 'KaSim' '-u' 'e' '-l' '200' '-seed' '904918633' '-o' 'data.svg' '-d' 'output' '-p' '4' 'abbc.ka' '-syntax' '3'</title>
 
 <style type="text/css" >
 <![CDATA[

--- a/models/test_suite/simulation/distance2_unary_abbc/README
+++ b/models/test_suite/simulation/distance2_unary_abbc/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -u event -l 200 -seed 438438234 -o data.svg -d output -p 2 abbc.ka || exit 0
+"${KAPPABIN}"KaSim -u event -l 200 -seed 438438234 -o data.svg -d output -p 2 abbc.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/distance2_unary_abbc/output/LOG.ref
+++ b/models/test_suite/simulation/distance2_unary_abbc/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (512 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-u' 'event' '-l' '200' '-seed' '438438234' '-o' 'data.svg' '-d' 'output' '-p' '2' 'abbc.ka'
++ Command line to rerun is: 'KaSim' '-u' 'event' '-l' '200' '-seed' '438438234' '-o' 'data.svg' '-d' 'output' '-p' '2' 'abbc.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/distance2_unary_abbc/output/data.svg.ref
+++ b/models/test_suite/simulation/distance2_unary_abbc/output/data.svg.ref
@@ -4,7 +4,7 @@
 
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="600">
-<title>Output of 'KaSim' '-u' 'event' '-l' '200' '-seed' '438438234' '-o' 'data.svg' '-d' 'output' '-p' '2' 'abbc.ka'</title>
+<title>Output of 'KaSim' '-u' 'event' '-l' '200' '-seed' '438438234' '-o' 'data.svg' '-d' 'output' '-p' '2' 'abbc.ka' '-syntax' '3'</title>
 
 <style type="text/css" >
 <![CDATA[

--- a/models/test_suite/simulation/distance_unary_a_bn_c/README
+++ b/models/test_suite/simulation/distance_unary_a_bn_c/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -u e -l 200 -seed 656095496 -o data.svg -d output -p 2 a_bn_c.ka || exit 0
+"${KAPPABIN}"KaSim -u e -l 200 -seed 656095496 -o data.svg -d output -p 2 a_bn_c.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/distance_unary_a_bn_c/output/LOG.ref
+++ b/models/test_suite/simulation/distance_unary_a_bn_c/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (512 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-u' 'e' '-l' '200' '-seed' '656095496' '-o' 'data.svg' '-d' 'output' '-p' '2' 'a_bn_c.ka'
++ Command line to rerun is: 'KaSim' '-u' 'e' '-l' '200' '-seed' '656095496' '-o' 'data.svg' '-d' 'output' '-p' '2' 'a_bn_c.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/distance_unary_a_bn_c/output/data.svg.ref
+++ b/models/test_suite/simulation/distance_unary_a_bn_c/output/data.svg.ref
@@ -4,7 +4,7 @@
 
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="600">
-<title>Output of 'KaSim' '-u' 'e' '-l' '200' '-seed' '656095496' '-o' 'data.svg' '-d' 'output' '-p' '2' 'a_bn_c.ka'</title>
+<title>Output of 'KaSim' '-u' 'e' '-l' '200' '-seed' '656095496' '-o' 'data.svg' '-d' 'output' '-p' '2' 'a_bn_c.ka' '-syntax' '3'</title>
 
 <style type="text/css" >
 <![CDATA[

--- a/models/test_suite/simulation/distance_unary_abbcd/README
+++ b/models/test_suite/simulation/distance_unary_abbcd/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -u event -l 200 -seed 718860825 -o data.svg -d output -p 2 abbcd.ka || exit 0
+"${KAPPABIN}"KaSim -u event -l 200 -seed 718860825 -o data.svg -d output -p 2 abbcd.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/distance_unary_abbcd/output/LOG.ref
+++ b/models/test_suite/simulation/distance_unary_abbcd/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (512 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-u' 'event' '-l' '200' '-seed' '718860825' '-o' 'data.svg' '-d' 'output' '-p' '2' 'abbcd.ka'
++ Command line to rerun is: 'KaSim' '-u' 'event' '-l' '200' '-seed' '718860825' '-o' 'data.svg' '-d' 'output' '-p' '2' 'abbcd.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/distance_unary_abbcd/output/data.svg.ref
+++ b/models/test_suite/simulation/distance_unary_abbcd/output/data.svg.ref
@@ -4,7 +4,7 @@
 
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="600">
-<title>Output of 'KaSim' '-u' 'event' '-l' '200' '-seed' '718860825' '-o' 'data.svg' '-d' 'output' '-p' '2' 'abbcd.ka'</title>
+<title>Output of 'KaSim' '-u' 'event' '-l' '200' '-seed' '718860825' '-o' 'data.svg' '-d' 'output' '-p' '2' 'abbcd.ka' '-syntax' '3'</title>
 
 <style type="text/css" >
 <![CDATA[

--- a/models/test_suite/simulation/marshal/README
+++ b/models/test_suite/simulation/marshal/README
@@ -2,7 +2,7 @@
 
 BLOB=/tmp/KaSim-test-blob-$(basename $PWD)
 
-"${KAPPABIN}"KaSim --compile -make-sim ${BLOB} -seed 496408597 -d output model.ka && \
-"${KAPPABIN}"KaSim --compile -load-sim ${BLOB} -seed 958076642 -d output && \
-"${KAPPABIN}"KaSim --compile -load-sim ${BLOB} -seed 458154606 -d output -var init 300 || exit 0
+"${KAPPABIN}"KaSim --compile -make-sim ${BLOB} -seed 496408597 -d output model.ka -syntax 3 && \
+"${KAPPABIN}"KaSim --compile -load-sim ${BLOB} -seed 958076642 -d output -syntax 3 && \
+"${KAPPABIN}"KaSim --compile -load-sim ${BLOB} -seed 458154606 -d output -var init 300 -syntax 3 || exit 0
 rm -f ${BLOB}

--- a/models/test_suite/simulation/marshal/output/LOG.ref
+++ b/models/test_suite/simulation/marshal/output/LOG.ref
@@ -13,12 +13,12 @@ done
 	 -initial conditions
 + Building initial state (256 agents)
 Done
-+ Command line to rerun is: 'KaSim' '--compile' '-make-sim' '/tmp/KaSim-test-blob-marshal' '-seed' '496408597' '-d' 'output' 'model.ka'
++ Command line to rerun is: 'KaSim' '--compile' '-make-sim' '/tmp/KaSim-test-blob-marshal' '-seed' '496408597' '-d' 'output' 'model.ka' '-syntax' '3'
 + Loading simulation package /tmp/KaSim-test-blob-marshal...
 + Building initial state (256 agents)
 Done
-+ Command line to rerun is: 'KaSim' '--compile' '-load-sim' '/tmp/KaSim-test-blob-marshal' '-seed' '958076642' '-d' 'output'
++ Command line to rerun is: 'KaSim' '--compile' '-load-sim' '/tmp/KaSim-test-blob-marshal' '-seed' '958076642' '-d' 'output' '-syntax' '3'
 + Loading simulation package /tmp/KaSim-test-blob-marshal...
 + Building initial state (1024 agents)
 Done
-+ Command line to rerun is: 'KaSim' '--compile' '-load-sim' '/tmp/KaSim-test-blob-marshal' '-seed' '458154606' '-d' 'output' '-var' 'init' '300'
++ Command line to rerun is: 'KaSim' '--compile' '-load-sim' '/tmp/KaSim-test-blob-marshal' '-seed' '458154606' '-d' 'output' '-var' 'init' '300' '-syntax' '3'

--- a/models/test_suite/simulation/overlapping_unaries/README
+++ b/models/test_suite/simulation/overlapping_unaries/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -l 120 -seed 56235278 -o data.svg -d output -p 0.84 overlapping_unaries.ka || exit 0
+"${KAPPABIN}"KaSim -l 120 -seed 56235278 -o data.svg -d output -p 0.84 overlapping_unaries.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/overlapping_unaries/output/LOG.ref
+++ b/models/test_suite/simulation/overlapping_unaries/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16384 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '120' '-seed' '56235278' '-o' 'data.svg' '-d' 'output' '-p' '0.84' 'overlapping_unaries.ka'
++ Command line to rerun is: 'KaSim' '-l' '120' '-seed' '56235278' '-o' 'data.svg' '-d' 'output' '-p' '0.84' 'overlapping_unaries.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/overlapping_unaries/output/data.svg.ref
+++ b/models/test_suite/simulation/overlapping_unaries/output/data.svg.ref
@@ -4,7 +4,7 @@
 
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="600">
-<title>Output of 'KaSim' '-l' '120' '-seed' '56235278' '-o' 'data.svg' '-d' 'output' '-p' '0.84' 'overlapping_unaries.ka'</title>
+<title>Output of 'KaSim' '-l' '120' '-seed' '56235278' '-o' 'data.svg' '-d' 'output' '-p' '0.84' 'overlapping_unaries.ka' '-syntax' '3'</title>
 
 <style type="text/css" >
 <![CDATA[

--- a/models/test_suite/simulation/perturbation_multiple_alarms/README
+++ b/models/test_suite/simulation/perturbation_multiple_alarms/README
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"${KAPPABIN}"KaSim -l 5 -d output -seed 20543 repeat_time.ka || exit 0
+"${KAPPABIN}"KaSim -l 5 -d output -seed 20543 repeat_time.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/perturbation_multiple_alarms/output/LOG.ref
+++ b/models/test_suite/simulation/perturbation_multiple_alarms/output/LOG.ref
@@ -15,7 +15,7 @@ done
 3rd printing alarm at 0.
  (16384 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '5' '-d' 'output' '-seed' '20543' 'repeat_time.ka'
++ Command line to rerun is: 'KaSim' '-l' '5' '-d' 'output' '-seed' '20543' 'repeat_time.ka' '-syntax' '3'
 ____________________________________________________________
 ########1st printing alarm at 0.7
 2nd printing alarm at 0.7

--- a/models/test_suite/simulation/perturbation_null_event/README
+++ b/models/test_suite/simulation/perturbation_null_event/README
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"${KAPPABIN}"KaSim -u Event -l 25 -d output -seed 20543 pert_null_event.ka || exit 0
+"${KAPPABIN}"KaSim -u Event -l 25 -d output -seed 20543 pert_null_event.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/perturbation_null_event/output/LOG.ref
+++ b/models/test_suite/simulation/perturbation_null_event/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (8 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-u' 'Event' '-l' '25' '-d' 'output' '-seed' '20543' 'pert_null_event.ka'
++ Command line to rerun is: 'KaSim' '-u' 'Event' '-l' '25' '-d' 'output' '-seed' '20543' 'pert_null_event.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/perturbation_periodic_time/README
+++ b/models/test_suite/simulation/perturbation_periodic_time/README
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"${KAPPABIN}"KaSim -l 5 -d output -seed 20543 repeat_time.ka || exit 0
+"${KAPPABIN}"KaSim -l 5 -d output -seed 20543 repeat_time.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/perturbation_periodic_time/output/LOG.ref
+++ b/models/test_suite/simulation/perturbation_periodic_time/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (16384 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '5' '-d' 'output' '-seed' '20543' 'repeat_time.ka'
++ Command line to rerun is: 'KaSim' '-l' '5' '-d' 'output' '-seed' '20543' 'repeat_time.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/rafinements/README
+++ b/models/test_suite/simulation/rafinements/README
@@ -1,1 +1,1 @@
-"${KAPPABIN}"KaSim -p 0.008 -d output rafinements.ka -o data.tsv -mode batch --max-sharing || exit 0
+"${KAPPABIN}"KaSim -p 0.008 -d output rafinements.ka -o data.tsv -mode batch --max-sharing -syntax 3 || exit 0

--- a/models/test_suite/simulation/rafinements/output/LOG.ref
+++ b/models/test_suite/simulation/rafinements/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (32768 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-p' '0.008' '-d' 'output' 'rafinements.ka' '-o' 'data.tsv' '-mode' 'batch' '--max-sharing'
++ Command line to rerun is: 'KaSim' '-p' '0.008' '-d' 'output' 'rafinements.ka' '-o' 'data.tsv' '-mode' 'batch' '--max-sharing' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/side_effect/README
+++ b/models/test_suite/simulation/side_effect/README
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"${KAPPABIN}"KaSim -l 1 -d output -seed 148153191 remove_nodes_and_link.ka || exit 0
+"${KAPPABIN}"KaSim -l 1 -d output -seed 148153191 remove_nodes_and_link.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/side_effect/output/LOG.ref
+++ b/models/test_suite/simulation/side_effect/output/LOG.ref
@@ -13,5 +13,5 @@ done
 	 -initial conditions
 + Building initial state (4 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '1' '-d' 'output' '-seed' '148153191' 'remove_nodes_and_link.ka'
++ Command line to rerun is: 'KaSim' '-l' '1' '-d' 'output' '-seed' '148153191' 'remove_nodes_and_link.ka' '-syntax' '3'
 Simulation ended

--- a/models/test_suite/simulation/species/README
+++ b/models/test_suite/simulation/species/README
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"${KAPPABIN}"KaSim -l 10 -d output -seed 1054220715 species.ka || exit 0
+"${KAPPABIN}"KaSim -l 10 -d output -seed 1054220715 species.ka -syntax 3 || exit 0

--- a/models/test_suite/simulation/species/output/LOG.ref
+++ b/models/test_suite/simulation/species/output/LOG.ref
@@ -13,7 +13,7 @@ done
 	 -initial conditions
 + Building initial state (512 agents)
 Done
-+ Command line to rerun is: 'KaSim' '-l' '10' '-d' 'output' '-seed' '1054220715' 'species.ka'
++ Command line to rerun is: 'KaSim' '-l' '10' '-d' 'output' '-seed' '1054220715' 'species.ka' '-syntax' '3'
 ____________________________________________________________
 ############################################################
 Simulation ended

--- a/models/test_suite/simulation/species_syntax/README
+++ b/models/test_suite/simulation/species_syntax/README
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"${KAPPABIN}"KaSim -l 10 -d output -seed 1054220715 species.ka || exit 0
+"${KAPPABIN}"KaSim -l 10 -d output -seed 1054220715 species.ka -syntax 3 || exit 0


### PR DESCRIPTION
Adds a command line to every KaSim invokation in the test suite. These were found in the respective README files in various folders. It now specifies the models are written in KaSim3 syntax. KaSa and KaDe invokations were not modified.

As several log files hold information about the command line used in their creation, they have been modified. These include certain reference data files, as their title contains information about the invokation.