### PR TITLE
Starting the port of KaSa test suite to syntax 4.

### DIFF
--- a/models/test_suite/kade/abc/README
+++ b/models/test_suite/kade/abc/README
@@ -1,6 +1,6 @@
 #Command-line:
-"${KAPPABIN}"KaDE ../../cflows/abc/abc.ka  -d output -l 1 -p 0.1 || exit 0
-"${KAPPABIN}"KaDE ../../cflows/abc/abc.ka  -d output -l 1 -p 0.1 --octave-output oct.m || exit 0
+"${KAPPABIN}"KaDE ../../cflows/abc/abc.ka  -d output -l 1 -p 0.1 -syntax 4 || exit 0
+"${KAPPABIN}"KaDE ../../cflows/abc/abc.ka  -d output -l 1 -p 0.1 -syntax 4 --octave-output oct.m || exit 0
 "${KAPPABIN}"KaDE ../../cflows/abc/abc.ka  -d output -l 1 -p 0.1 -syntax 4 --ode-backend SBML || exit 0
 "${KAPPABIN}"KaDE ../../cflows/abc/abc.ka  -d output -l 1 -p 0.1 -syntax 4 --ode-backend SBML --sbml-output abc.xml || exit 0
 #This is the classical abc model.

--- a/models/test_suite/kade/tokens/README
+++ b/models/test_suite/kade/tokens/README
@@ -1,5 +1,5 @@
 #Command-line:
-"${KAPPABIN}"KaDE ../../compiler/tokens/tokens.ka -syntax 3 -d output -l 1 -p 0.1 || exit 0
-"${KAPPABIN}"KaDE ../../compiler/tokens/tokens.ka -syntax 3 -d output -l 1 -p 0.1 --ode-backend SBML || exit 0
+"${KAPPABIN}"KaDE ../../compiler/tokens/tokens.ka -syntax 4 -d output -l 1 -p 0.1 || exit 0
+"${KAPPABIN}"KaDE ../../compiler/tokens/tokens.ka -syntax 4 -d output -l 1 -p 0.1 --ode-backend SBML || exit 0
 
 #This is the classical abc model.


### PR DESCRIPTION
KaSa porting -> models under test_suite/kasa_preprocessing

KaSa parses a file KaSim won't:
```
File "kasa_preprocessing/bdu_analysis/bdu_analysis.ka", line 9, characters 14-15:
"u" is not a declared internal state for site x.
```
The file contains a rule that uses an internal state not declared in the agent signature.
When parsing, KaSim issues the error above. KaSa however continues without exception; it finds the "u" internal state and adds a green blob to the contact map.

Idem for:
```
File "kasa_preprocessing/bind/bind.ka", line 13, characters 32-33:
"u" is not a declared internal state for site x.
```

LHS <-> RHS agent mismatch raises a very cryptic error, in 6-fold copy:
```
Some exceptions have been raised
error: file_name: KaSa_rep/data_structures/int_storage.ml; message: line 130; exception:Exit
error: file_name: KaSa_rep/influence_map/algebraic_construction.ml; message: line 147: Should not scan empty agents...; exception:Exit
error: file_name: KaSa_rep/data_structures/int_storage.ml; message: line 130; exception:Exit
error: file_name: KaSa_rep/influence_map/algebraic_construction.ml; message: line 147: Should not scan empty agents...; exception:Exit
error: file_name: KaSa_rep/data_structures/int_storage.ml; message: line 130; exception:Exit
error: file_name: KaSa_rep/influence_map/algebraic_construction.ml; message: line 147: Should not scan empty agents...; exception:Exit
error: file_name: KaSa_rep/data_structures/int_storage.ml; message: line 130; exception:Exit
error: file_name: KaSa_rep/influence_map/algebraic_construction.ml; message: line 147: Should not scan empty agents...; exception:Exit
error: file_name: KaSa_rep/data_structures/int_storage.ml; message: line 130; exception:Exit
error: file_name: KaSa_rep/influence_map/algebraic_construction.ml; message: line 147: Should not scan empty agents...; exception:Exit
error: file_name: KaSa_rep/data_structures/int_storage.ml; message: line 130; exception:Exit
error: file_name: KaSa_rep/influence_map/algebraic_construction.ml; message: line 147: Should not scan empty agents...; exception:Exit
```
This mismatch is of type `A() <-> B()` (i.e. user forgot the dots to mark deletion & creation). I would encourage a more precise error message...

Going over the error file resulting from `$make check`, there are discrepancies in the labels for influence maps. The label is of the form `[pos A] -> [pos B]`, where these are positions of agents in the rule. In KaSimV4, creation/deletion of agents inserts periods, thereby changing the position of agents vis a vis KaSimV3 syntax.

Other discrepancies lie in how KaSa communicates rules, it uses the start and end (i.e. the start of the next), leading to messages that imply a rule spans multiple lines, e.g.
```
-	Applying rule r0 (File "haft_unbinding.ka", line 11, characters 4-22:):
+	Applying rule r0 (File "haft_unbinding.ka", lines 11-12, characters 5-0:):
```
KaSa could ignore trailing whitespace to remove this discrepancy...
