### PR TITLE
Update render-contactmap.js

### DIFF
--- a/viz/render-contactmap.js
+++ b/viz/render-contactmap.js
@@ -246,7 +246,7 @@ class Render {
             .attr("d", line)
             .attr("stroke", "steelblue")
             .attr("stroke-width", 2)
-            .attr("fill", "white")
+            .attr("fill", "transparent")
             .style("stroke-opacity", opacity.line_normal)
             .on("mouseover", mouseoverLink)
             .on("mouseout", mouseoutLink)


### PR DESCRIPTION
Set the fill attribute of links to transparent, rather than white, to avoid them occluding links behind them. Should solve (part of) issue #420