### PR TITLE
Update packaging Makefile rules using Electron.js instead of NWJS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,20 +156,20 @@ temp-clean-for-ignorant-that-clean-must-be-done-before-fetch:
 	find . \( -name \*.cm\* -or -name \*.o -or -name \*.annot \) -delete
 	rm -f grammar/kappaLexer.ml grammar/kappaParser.ml grammar/kappaParser.mli
 
+# https://electronjs.org/docs/tutorial/application-distribution
+
 Kappapp.tar.gz:
 	+$(MAKE) clean
 	+$(MAKE) APP_EXT=local site/index.html
 	dune build --only-packages kappa-library,kappa-binaries,kappa-agents
-	FILE=$$(mktemp -t nwjsXXXX); \
-	curl -LsS -o $$FILE https://dl.nwjs.io/v$(NWJS_VERSION)/nwjs-v$(NWJS_VERSION)-linux-x64.tar.gz && \
-	tar xzf $$FILE && rm -f $$FILE
 	mkdir Kappapp
-	mv nwjs-v$(NWJS_VERSION)-linux-x64/* Kappapp/
-	rmdir nwjs-v$(NWJS_VERSION)-linux-x64
-	mv Kappapp/nw Kappapp/kappapp
-	mv site Kappapp/package.nw
-	mkdir Kappapp/bin
-	cp bin/* Kappapp/bin/
+	FILE=$$(mktemp -t electronXXXX); \
+	curl -LsS -o $$FILE https://github.com/electron/electron/releases/download/v$(ELECTRON_VERSION)/electron-v$(ELECTRON_VERSION)-linux-x64.zip && \
+	unzip $$FILE -d Kappapp
+	mv Kappapp/electron Kappapp/kappapp
+	mv site Kappapp/resources/app
+	mkdir Kappapp/resources/bin
+	cp bin/* Kappapp/resources/bin/
 	tar czf $@ Kappapp
 	rm -r Kappapp
 
@@ -178,37 +178,33 @@ KappaBin.zip:
 	+$(MAKE) APP_EXT=local site/index.html
 	dune build -x windows --only-packages kappa-library,kappa-binaries,kappa-agents
 	mkdir KappaBin
-	mkdir KappaBin/bin
-	mv site KappaBin/package.nw
-	FILE=$$(mktemp -t nwjsXXXX); \
-	curl -LsS -o $$FILE https://dl.nwjs.io/v$(NWJS_VERSION)/nwjs-v$(NWJS_VERSION)-win-x64.zip && \
-	unzip $$FILE && rm -f $$FILE
-	mv nwjs-v$(NWJS_VERSION)-win-x64/* KappaBin/
-	rmdir nwjs-v$(NWJS_VERSION)-win-x64
-	mv KappaBin/nw.exe KappaBin/Kappapp.exe
-	cp _build/default.windows/main/KaSim.exe KappaBin/bin/
-	cp _build/default.windows/KaSa_rep/main/KaSa.exe KappaBin/bin/
-	cp _build/default.windows/agents/KaStor.exe KappaBin/bin/
-	cp _build/default.windows/odes/KaDE.exe KappaBin/bin/
-	cp _build/default.windows/agents/KaSimAgent.exe KappaBin/bin/
-	cp _build/default.windows/agents/KaSaAgent.exe KappaBin/bin/
+	FILE=$$(mktemp -t electronXXXX); \
+	curl -LsS -o $$FILE https://github.com/electron/electron/releases/download/v$(ELECTRON_VERSION)/electron-v$(ELECTRON_VERSION)-win32-x64.zip && \
+	unzip $$FILE -d KappaBin
+	mv site KappaBin/resources/app
+	mv KappaBin/electron.exe KappaBin/Kappapp.exe
+	mkdir KappaBin/resources/bin
+	cp _build/default.windows/main/KaSim.exe KappaBin/resources/bin/
+	cp _build/default.windows/KaSa_rep/main/KaSa.exe KappaBin/resources/bin/
+	cp _build/default.windows/agents/KaStor.exe KappaBin/resources/bin/
+	cp _build/default.windows/odes/KaDE.exe KappaBin/resources/bin/
+	cp _build/default.windows/agents/KaSimAgent.exe KappaBin/resources/bin/
+	cp _build/default.windows/agents/KaSaAgent.exe KappaBin/resources/bin/
 	zip -y -r $@ KappaBin
 	rm -r KappaBin
 
-Kappapp.app:
+Kappapp.app: ide/Info.plist ide/Kappa.icns
 	+$(MAKE) clean
 	+$(MAKE) APP_EXT=local site/index.html
 	dune build --only-packages kappa-library,kappa-binaries,kappa-agents
 	+$(MAKE) ide/Kappa.icns ide/Info.plist
-	FILE=$$(mktemp -t nwjsXXXX); \
-	curl -LsS -o $$FILE https://dl.nwjs.io/v$(NWJS_VERSION)/nwjs-v$(NWJS_VERSION)-osx-x64.zip && \
-	unzip $$FILE && rm -f $$FILE
-	mv nwjs-v$(NWJS_VERSION)-osx-x64/nwjs.app $@
-	rm -r nwjs-v$(NWJS_VERSION)-osx-x64/
+	FILE=$$(mktemp -t electronXXXX); FOLDER=$$(mktemp -t electron_unzipedXXXX); \
+	curl -LsS -o $$FILE https://github.com/electron/electron/releases/download/v$(ELECTRON_VERSION)/electron-v$(ELECTRON_VERSION)-darwin-x64.zip && \
+	rm $$FOLDER && mkdir -p $$FOLDER && pushd $$FOLDER && unzip $$FILE && popd && mv $$FOLDER/Electron.app $@ && rm -r $$FOLDER
 	rm -r $@/Contents/Resources/*.lproj/
 	mkdir $@/Contents/Resources/bin
 	cp bin/* $@/Contents/Resources/bin/
-	mv site $@/Contents/Resources/app.nw
+	mv site $@/Contents/Resources/app/
 	mv ide/Kappa.icns $@/Contents/Resources/
 	mv ide/Info.plist $@/Contents/
 

--- a/externals.mk
+++ b/externals.mk
@@ -1,5 +1,7 @@
-NWJS_VERSION:=0.35.5
 CODEMIRROR_VERSION:=5.42.2
 BOOTSTRAP_VERSION:=3.3.7
 JQUERY_VERSION:=3.2.1
 JQUERY_UI_VERSION:=1.12.1
+
+# https://github.com/electron/electron-api-demos/releases
+ELECTRON_VERSION:=3.1.6

--- a/ide/Info.plist.skel
+++ b/ide/Info.plist.skel
@@ -5,7 +5,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>org.executableknowledge.kappapp</string>
 	<key>CFBundleExecutable</key>
-	<string>nwjs</string>
+	<string>Electron</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>LSApplicationCategoryType</key>
@@ -25,7 +25,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
-	<string>NWJS</string>
+	<string>Electron</string>
 	<key>CFBundleIconFile</key>
 	<string>Kappa.icns</string>
 	<key>CFBundleDocumentTypes</key>
@@ -66,5 +66,23 @@
 	<string>10.9.0</string>
 	<key>NSUserNotificationAlertStyle</key>
 	<string>banner</string>
+	<key>BuildMachineOSBuild</key>
+	<string>16G1710</string>
+	<key>DTSDKBuild</key>
+	<string>16E185</string>
+	<key>DTSDKName</key>
+	<string>macosx10.1210.12</string>
+	<key>DTXcode</key>
+	<string>0833</string>
+	<key>DTXcodeBuild</key>
+	<string>8E3004b</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>AtomApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 </dict>
 </plist>

--- a/js/package.json
+++ b/js/package.json
@@ -1,8 +1,15 @@
 {
-    "name": "Kappa",
-    "main": "index.html?host=file%3A%2F%2F..%2Fbin%2FKaSimAgent%3Flabel%3DLocal",
-    "window": {
-	"min_width": 1024,
-	"min_height": 768
-    }
+  "name": "kappapp",
+  "version": "4.0.0",
+  "description": "Tool suite for kappa models. Documentation and binaries can be found in the release section. Try it online at http://kappalanguage.org/",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "repository": "https://github.com/Kappa-Dev/KaSim",
+  "author": "GitHub",
+  "license": "LGPL-3.0",
+  "devDependencies": {
+    "electron": "^4.0.7"
+  }
 }

--- a/viz/main.js
+++ b/viz/main.js
@@ -1,0 +1,57 @@
+// Modules to control application life and create native browser window
+const {app, BrowserWindow} = require('electron')
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow
+
+function createWindow () {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({
+    width: 1024,
+    height: 600,
+    webPreferences: {
+      // https://electronjs.org/docs/faq#i-can-not-use-jqueryrequirejsmeteorangularjs-in-electron
+      nodeIntegration: false
+    }
+  })
+
+  // and load the index.html of the app.
+  mainWindow.loadFile('index.html')
+
+  // Open the DevTools.
+  // mainWindow.webContents.openDevTools()
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On macOS it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', function () {
+  // On macOS it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow()
+  }
+})
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.


### PR DESCRIPTION
https://electronjs.org/

This experiment was firstly motivated by finding a workaround to deal with the "blur" bug [1] (on Apple retina displays).

I discover by comparing Electron default `Info.plist` and the one generated by `Info.plist.skel` that we lack the property:

	<key>NSHighResolutionCapable</key>
	<true/>

as explained in this old documentation: https://developer.apple.com/library/archive/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html

The choice of switching from NWJS to Electron was motivated by the:
- good support of Electron by community and Microsoft
- native capabilities API we let us implement in a near futur:
	* automatic updates (eg. from GitHub releases)
	* crash reports (eg. to GitHub issues)

[1] To visualize the "blur" bug, here are two screenshots (taken on Macbook Pro 13', with default scale for display, in full screen mode):

- before (this patch):

![](https://user-images.githubusercontent.com/705213/54425296-df1e5f00-470c-11e9-9eb9-2691bf660e0c.png)

- after:

![](https://user-images.githubusercontent.com/705213/54425295-df1e5f00-470c-11e9-8b4b-59f48e124c7e.png)