### PR TITLE
gracefully handle case when binaries not found (in Py3 compatible way); add nose as dependency

### DIFF
--- a/python/kappy/kappa_std.py
+++ b/python/kappy/kappa_std.py
@@ -16,6 +16,7 @@ from kappy.kappa_common import KappaError, PlotLimit, FileMetadata, File, \
 
 def find_agent_bin():
     agent_names = ['KaSimAgent', 'KaSaAgent']
+    bin_dir = None
     for potential_dir in [KAPPY_DIR, KASIM_DIR]:
         bin_dir = path.join(potential_dir, 'bin')
         if not path.exists(bin_dir):
@@ -23,8 +24,6 @@ def find_agent_bin():
         contents = listdir(bin_dir)
         if all([agent in contents for agent in agent_names]):
             break
-    else:
-        raise KappaError("Could not find directory with agents.")
     return bin_dir
 
 
@@ -46,6 +45,10 @@ class KappaStd(KappaApi):
         self.project_ast = None
         self.analyses_to_init = True
         if kappa_bin_path is None:
+            if BIN_DIR is None:
+                # binaries must either exist in kappy directory or
+                # their location must be passed to this class
+                raise KappaError("Kappa binaries not found.")
             kappa_bin_path = BIN_DIR
         sim_args = [path.join(kappa_bin_path, "KaSimAgent"),
                     "--delimiter",

--- a/python/kappy/kappa_std.py
+++ b/python/kappy/kappa_std.py
@@ -106,6 +106,9 @@ class KappaStd(KappaApi):
             while c != self.delimiter.encode('utf-8') and c:
                 buff.extend(c)
                 c = self.sim_agent.stdout.read(1)
+            # error checking here?
+            print("buff: ")
+            print(buff.decode('utf-8'))
             response = json.loads(buff.decode('utf-8'))
             if response["id"] != message_id:
                 raise KappaError(

--- a/python/kappy/kappa_std.py
+++ b/python/kappy/kappa_std.py
@@ -106,9 +106,6 @@ class KappaStd(KappaApi):
             while c != self.delimiter.encode('utf-8') and c:
                 buff.extend(c)
                 c = self.sim_agent.stdout.read(1)
-            # error checking here?
-            print("buff: ")
-            print(buff.decode('utf-8'))
             response = json.loads(buff.decode('utf-8'))
             if response["id"] != message_id:
                 raise KappaError(

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,16 @@ import subprocess
 import setuptools.command.build_ext
 import os.path
 
+def should_build_agents():
+    """
+    Should we build agents? Currently this is decided based on
+    checking for existence of a .ml file. Ideally, this should
+    be made into a flag.
+    """
+    if os.path.isfile('agents/KaMoHa.ml'):
+        return True
+    return False
+
 class BuildAgentsCommand(distutils.cmd.Command):
     """Instruction to compile Kappa agents"""
 
@@ -21,25 +31,36 @@ class BuildAgentsCommand(distutils.cmd.Command):
         ()
 
     def run(self):
-        if os.path.isfile('agents/KaMoHa.ml'):
-            subprocess.check_call(["make","all","agents"])
+        status = False
+        if should_build_agents():
+            try:
+                subprocess.check_call(["make","all","agents"])
+            except subprocess.CalledProcessError:
+                print "Failed to compile Kappa agents. Installing Python " \
+                      "wrapper only."
+                return status
+            status = True
+        return status
 
 class MyBuildExtCommand(setuptools.command.build_ext.build_ext):
     """Compile Kappa agent in addition of standard build"""
 
     def run(self):
         self.my_outputs = []
-        if os.path.isfile('agents/KaMoHa.ml'):
-            self.run_command('build_agents')
-            bin_dir = os.path.join(self.build_lib, 'kappy/bin')
-            distutils.dir_util.mkpath(bin_dir)
-            distutils.file_util.copy_file("bin/KaSimAgent", bin_dir)
-            self.my_outputs.append(os.path.join(bin_dir, "KaSimAgent"))
-            distutils.file_util.copy_file("bin/KaSaAgent", bin_dir)
-            self.my_outputs.append(os.path.join(bin_dir, "KaSaAgent"))
-            distutils.file_util.copy_file("bin/KaMoHa", bin_dir)
-            self.my_outputs.append(os.path.join(bin_dir, "KaMoHa"))
-            setuptools.command.build_ext.build_ext.run(self)
+        if should_build_agents():
+            build_success = self.run_command('build_agents')
+            if build_success:
+                # if we were able to build agents, move them to
+                # appropriate binary directories
+                bin_dir = os.path.join(self.build_lib, 'kappy/bin')
+                distutils.dir_util.mkpath(bin_dir)
+                distutils.file_util.copy_file("bin/KaSimAgent", bin_dir)
+                self.my_outputs.append(os.path.join(bin_dir, "KaSimAgent"))
+                distutils.file_util.copy_file("bin/KaSaAgent", bin_dir)
+                self.my_outputs.append(os.path.join(bin_dir, "KaSaAgent"))
+                distutils.file_util.copy_file("bin/KaMoHa", bin_dir)
+                self.my_outputs.append(os.path.join(bin_dir, "KaMoHa"))
+                setuptools.command.build_ext.build_ext.run(self)
 
     def get_outputs(self):
         outputs = setuptools.command.build_ext.build_ext.get_outputs(self)

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(name='kappy',
           'build_agents': BuildAgentsCommand,
           'build_ext': MyBuildExtCommand,
       },
-      install_requires=['requests', 'future'],
+      install_requires=['requests', 'future', 'nose'],
       package_dir={'':'python'},
       include_package_data=True,
       data_files=[

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class MyBuildExtCommand(setuptools.command.build_ext.build_ext):
                 self.my_outputs.append(os.path.join(bin_dir, "KaSaAgent"))
                 distutils.file_util.copy_file("bin/KaMoHa", bin_dir)
                 self.my_outputs.append(os.path.join(bin_dir, "KaMoHa"))
-                setuptools.command.build_ext.build_ext.run(self)
+        setuptools.command.build_ext.build_ext.run(self)
 
     def get_outputs(self):
         outputs = setuptools.command.build_ext.build_ext.get_outputs(self)

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ class BuildAgentsCommand(distutils.cmd.Command):
             try:
                 subprocess.check_call(["make","all","agents"])
             except subprocess.CalledProcessError:
-                print "Failed to compile Kappa agents. Installing Python " \
-                      "wrapper only."
+                print("Failed to compile Kappa agents. Installing Python " \
+                      "wrapper only.")
                 return status
             status = True
         return status

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class MyBuildExtCommand(setuptools.command.build_ext.build_ext):
                 self.my_outputs.append(os.path.join(bin_dir, "KaSaAgent"))
                 distutils.file_util.copy_file("bin/KaMoHa", bin_dir)
                 self.my_outputs.append(os.path.join(bin_dir, "KaMoHa"))
-        setuptools.command.build_ext.build_ext.run(self)
+                setuptools.command.build_ext.build_ext.run(self)
 
     def get_outputs(self):
         outputs = setuptools.command.build_ext.build_ext.get_outputs(self)


### PR DESCRIPTION
This pull request:
1. Ensures that kappy will gracefully if the binaries for KaSim are not packaged with it (unlike before it will do so in a Py3 compatible way - got rid of the Py2 syntax).
2. Adds "nose" as a dependency in ``setup.py`` since the unit tests use it.