### PR TITLE
Update render-contactmap.js

### DIFF
--- a/viz/render-contactmap.js
+++ b/viz/render-contactmap.js
@@ -492,7 +492,7 @@ class Render {
                             })
                             .attr("class", "stateText")
                             .attr("id", "stateText" + "a" + site.agent.id + "s" + site.id + "id" + state)
-                            .attr('alignment-baseline', "middle")
+                            .attr('dominant-baseline', "central")
                             .style("fill", d => site.agent.color.darker() )
                             .style('font-size', d => {
                                 let textSize = 2000 / (siteNum/4 + 6 * site.states.length - this.radius/25);
@@ -669,7 +669,7 @@ class Render {
                 else
                     return "end"; })
             .attr("class", "siteText siteText--normal")
-            .attr('alignment-baseline', "middle")
+            .attr('dominant-baseline', "central")
             .attr("transform", d => {
                 let xy = siteArc.centroid(d) ;
                 let angle = ( d.startAngle + d.endAngle + 3 * Math.PI ) / 2;


### PR DESCRIPTION
Apply fix for #541 to site names (gSites) and state labels (gStates), not just to agent names (gNodes).

Use `dominant-baseline="central"` instead of `alignment-baseline="middle"`; although the `alignment-baseline` property can be applied to `text` objects, it has no effect on them (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alignment-baseline)